### PR TITLE
Add a console tracker for testing / development

### DIFF
--- a/RFS/src/test/java/com/rfs/tracing/TestContext.java
+++ b/RFS/src/test/java/com/rfs/tracing/TestContext.java
@@ -2,18 +2,26 @@ package com.rfs.tracing;
 
 import lombok.Getter;
 import org.opensearch.migrations.tracing.BacktracingContextTracker;
+import org.opensearch.migrations.tracing.CompositeContextTracker;
 import org.opensearch.migrations.tracing.IContextTracker;
 import org.opensearch.migrations.tracing.InMemoryInstrumentationBundle;
+import org.opensearch.migrations.tracing.LoggingContextTracer;
 
-public class TestContext extends RootRfsContext {  @Getter
+public class TestContext extends RootRfsContext {
+    @Getter
     public InMemoryInstrumentationBundle instrumentationBundle;
 
-    public static TestContext withTracking(boolean tracing, boolean metrics) {
-        return new TestContext(new InMemoryInstrumentationBundle(tracing, metrics), new BacktracingContextTracker());
+    public static TestContext withTracking(boolean tracing, boolean metrics, boolean consoleLogging) {
+        IContextTracker tracker = new BacktracingContextTracker();
+        if (consoleLogging) {
+            tracker = new CompositeContextTracker(tracker, new LoggingContextTracer());
+        }
+
+        return new TestContext(new InMemoryInstrumentationBundle(tracing, metrics), tracker);
     }
 
     public static TestContext withAllTracking() {
-        return withTracking(true, true);
+        return withTracking(true, true, true);
     }
 
     public static TestContext noOtelTracking() {

--- a/coreUtilities/src/testFixtures/java/org/opensearch/migrations/tracing/LoggingContextTracer.java
+++ b/coreUtilities/src/testFixtures/java/org/opensearch/migrations/tracing/LoggingContextTracer.java
@@ -1,0 +1,27 @@
+package org.opensearch.migrations.tracing;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LoggingContextTracer implements IContextTracker {
+
+    private static final String CREATED_MESSAGE = "<< Start: {}";
+    private static final String CLOSED_MESSAGE  = ">> Close: {} {}";
+
+    @Override
+    public void onContextCreated(final IScopedInstrumentationAttributes context) {
+        log.atDebug()
+            .setMessage(CREATED_MESSAGE)
+            .addArgument(context.getActivityName())
+            .log();
+    }
+
+    @Override
+    public void onContextClosed(IScopedInstrumentationAttributes context) {
+        log.atDebug()
+            .setMessage(CLOSED_MESSAGE)
+            .addArgument(context.getActivityName())
+            .addArgument(context::getPopulatedSpanAttributes)
+            .log();
+    }
+}


### PR DESCRIPTION
### Description
Add a console tracker for testing / development

### Testing
Manually validated test output includes the console tracker feature

#### Example output from RestClientTest
```
17:30:48.521 Test worker DEBUG LoggingContextTracer:16 - << Start: createSnapshot
17:30:48.522 Test worker DEBUG LoggingContextTracer:16 - << Start: httpRequest
17:30:49.077 Test worker DEBUG LoggingContextTracer:16 - << Start: httpRequest
17:30:49.086 reactor-http-epoll-2 DEBUG LoggingContextTracer:25 - >> Close: httpRequest {bytesRead=66, bytesSent=139, callType="createSnapshotContext"}
17:30:49.098 Test worker DEBUG LoggingContextTracer:25 - >> Close: createSnapshot {}
17:30:49.098 reactor-http-epoll-3 DEBUG LoggingContextTracer:25 - >> Close: httpRequest {bytesRead=66, bytesSent=133, callType="createGetSnapshotContext"}
```

### Check List
- [ ] ~New functionality includes testing~
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
