### PR TITLE
Remove use of Optional for logging messages in setupShutdownHookForReplayer

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -347,20 +347,16 @@ public class TrafficReplayer {
             // both Log4J and the java builtin loggers add shutdown hooks.
             // The API for addShutdownHook says that those hooks registered will run in an undetermined order.
             // Hence, the reason that this code logs via slf4j logging AND stderr.
-            Optional.of("Running TrafficReplayer Shutdown.  "
-                    + "The logging facilities may also be shutting down concurrently, "
-                    + "resulting in missing logs messages.")
-                .ifPresent(beforeMsg -> {
-                    log.atWarn().setMessage(beforeMsg).log();
-                    System.err.println(beforeMsg);
-                });
+            var beforeMsg = "Running TrafficReplayer Shutdown.  "
+                + "The logging facilities may also be shutting down concurrently, "
+                + "resulting in missing logs messages.";
+            log.atWarn().setMessage(beforeMsg).log();
+            System.err.println(beforeMsg);
             Optional.ofNullable(weakTrafficReplayer.get()).ifPresent(o -> o.shutdown(null));
-            Optional.of("Done shutting down TrafficReplayer (due to Runtime shutdown).  "
-                    + "Logs may be missing for events that have happened after the Shutdown event was received.")
-                .ifPresent(afterMsg -> {
-                    log.atWarn().setMessage(afterMsg).log();
-                    System.err.println(afterMsg);
-                });
+            var afterMsg = "Done shutting down TrafficReplayer (due to Runtime shutdown).  "
+                + "Logs may be missing for events that have happened after the Shutdown event was received.";
+            log.atWarn().setMessage(afterMsg).log();
+            System.err.println(afterMsg);
         }));
     }
 


### PR DESCRIPTION
### Description
Remove use of Optional for logging messages in setupShutdownHookForReplayer

### Check List
- [ ] ~New functionality includes testing~
  - [ ] ~All tests pass, including unit test, integration test and doctest~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
