### PR TITLE
Drop jsonPath cast, normalize jsonPath types, and validate snapshot JSON wiring

### DIFF
--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/createOrGetSnapshot.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/createOrGetSnapshot.ts
@@ -77,7 +77,7 @@ export const CreateOrGetSnapshot = WorkflowBuilder.create({
                     ...selectInputsForKeys(b, getAcceptedRegisterKeys(c)),
                     snapshotConfig: expr.serialize(
                         expr.makeDict({
-                            repoConfig: expr.jsonPathStrict(b.inputs.snapshotConfig, "repoConfig"),
+                            repoConfig: expr.deserializeRecord(expr.jsonPathStrict(b.inputs.snapshotConfig, "repoConfig")),
                             snapshotName: expr.toLowerCase(c.steps.getSnapshotName.outputs.snapshotName),
                             label: expr.jsonPathStrict(b.inputs.snapshotConfig, "label"),
                         })

--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/documentBulkLoad.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/documentBulkLoad.ts
@@ -425,7 +425,7 @@ export const DocumentBulkLoad = WorkflowBuilder.create({
                             b.inputs.documentBackfillConfig,
                             b.inputs.sessionName)
                     )),
-                    resources: expr.serialize(expr.jsonPathStrict(b.inputs.documentBackfillConfig, "resources")),
+                    resources: expr.jsonPathStrict(b.inputs.documentBackfillConfig, "resources"),
                     sourceK8sLabel: b.inputs.sourceLabel,
                     targetK8sLabel: expr.jsonPathStrict(b.inputs.targetConfig, "label"),
                     snapshotK8sLabel: expr.jsonPathStrict(b.inputs.snapshotConfig, "label"),

--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/fullMigration.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/fullMigration.ts
@@ -361,7 +361,7 @@ export const FullMigration = WorkflowBuilder.create({
                 c.register({
                     ...selectInputsForRegister(b, c),
                     sourceConfig: b.inputs.sourceConfig,
-                    createSnapshotConfig: expr.jsonPathStrictSerialized(b.inputs.snapshotItemConfig, "config"),
+                    createSnapshotConfig: expr.jsonPathStrict(b.inputs.snapshotItemConfig, "config"),
                     snapshotPrefix: expr.get(
                         expr.deserializeRecord(b.inputs.snapshotItemConfig), "snapshotPrefix"),
                     snapshotConfig: expr.serialize(expr.makeDict({
@@ -369,7 +369,7 @@ export const FullMigration = WorkflowBuilder.create({
                             createSnapshotConfig: expr.get(
                                 expr.deserializeRecord(b.inputs.snapshotItemConfig), "config")
                         }),
-                        repoConfig: expr.deserializeRecord(expr.jsonPathStrictSerialized(b.inputs.snapshotItemConfig, "repo")),
+                        repoConfig: expr.deserializeRecord(expr.jsonPathStrict(b.inputs.snapshotItemConfig, "repo")),
                         // TODO: label should be the logical snapshot name (record key from user config),
                         // not snapshotPrefix. PER_SOURCE_CREATE_SNAPSHOTS_CONFIG needs a label field.
                         label: expr.get(
@@ -413,7 +413,7 @@ export const FullMigration = WorkflowBuilder.create({
                 c.register({
                     ...selectInputsForRegister(b, c),
                     snapshotItemConfig: expr.serialize(c.item),
-                    sourceConfig: expr.jsonPathStrictSerialized(b.inputs.snapshotsSourceConfig, "sourceConfig")
+                    sourceConfig: expr.jsonPathStrict(b.inputs.snapshotsSourceConfig, "sourceConfig")
                 }), {
                     loopWith: makeParameterLoop(
                         expr.get(expr.deserializeRecord(b.inputs.snapshotsSourceConfig),
@@ -494,8 +494,8 @@ export const FullMigration = WorkflowBuilder.create({
                             getZodKeys(PER_INDICES_SNAPSHOT_MIGRATION_CONFIG)),
                         sourceVersion: expr.jsonPathStrict(b.inputs.snapshotMigrationConfig, "sourceVersion"),
                         sourceLabel: expr.jsonPathStrict(b.inputs.snapshotMigrationConfig, "sourceLabel"),
-                        targetConfig: expr.jsonPathStrictSerialized(b.inputs.snapshotMigrationConfig, "targetConfig"),
-                        snapshotConfig: expr.jsonPathStrictSerialized(b.inputs.snapshotMigrationConfig, "snapshotConfig"),
+                        targetConfig: expr.jsonPathStrict(b.inputs.snapshotMigrationConfig, "targetConfig"),
+                        snapshotConfig: expr.jsonPathStrict(b.inputs.snapshotMigrationConfig, "snapshotConfig"),
                         migrationLabel: expr.get(c.item, "label"),
                         groupName: expr.get(c.item, "label")
                     });


### PR DESCRIPTION
### Motivation
- Remove a risky type cast used to coerce `jsonPathStrict` results and rely on stronger typing instead. 
- Ensure `jsonPathStrict` returns JSON-friendly, mutable shapes for downstream use (avoid readonly array mismatches). 
- Verify that `createSnapshot` receives concrete JSON for the `---INLINE-JSON` argument (not an Argo expression string). 

### Description
- Added `DeepNormalizeJsonPath` and updated `JsonPathResult` so `jsonPathStrict` normalizes readonly/object shapes into mutable JSON-compatible types while preserving `Serialized` semantics. 
- Eliminated the explicit `expr.cast(...)` usage for `createSnapshotConfig` and replaced uses of the removed `jsonPathStrictSerialized` with `jsonPathStrict` plus `deserializeRecord` where appropriate. 
- Adjusted templates to pass `jsonPathStrict(...)` results directly in `fullMigration`, `createOrGetSnapshot`, and `documentBulkLoad`. 
- Tightened `serialize` input typing to accept only non-serialized plain objects and updated expression type tests to match the new contracts. 

### Testing
- Ran builder unit tests: `npm run -w @opensearch-migrations/argo-workflow-builders test` — all tests passed. 
- Ran template type checks: `npm run -w @opensearch-migrations/migration-workflow-templates type-check` — type-check passed. 
- Regenerated templates: `npm run make-templates -- --createResources false --outputDirectory ${PWD}/k8sResources` — templates written successfully. 
- Transformed sample config with the initializer: `npx tsx packages/config-processor/src/runMigrationInitializer.ts --user-config packages/config-processor/scripts/samples/basicSnapshotMigration.wf.yaml --unique-run-nonce testnonce --etcd-endpoints http://localhost:2379 --output-dir ./tmp-wf-init-out --skip-initialize` — succeeded and produced `workflowMigration.config.yaml` showing `createSnapshotConfig` as concrete JSON; inspected generated YAMLs to confirm `createSnapshotConfig` passes via evaluated `jsonpath(...)` and `CreateSnapshot` receives `---INLINE-JSON` with a `toJSON(...)` payload. 
- Attempt to run `deployment/k8s/localTesting.sh` failed in this environment due to missing `minikube` (`minikube: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d66786db48333898e70d7c5d8a588)