### PR TITLE
Add gated capture-proxy clientAuth (mTLS) e2e mutator + spec

### DIFF
--- a/orchestrationSpecs/packages/e2e-orchestration-tests/src/fixtures/builtinMutators.ts
+++ b/orchestrationSpecs/packages/e2e-orchestration-tests/src/fixtures/builtinMutators.ts
@@ -10,6 +10,7 @@
 import { Mutator } from "./mutators";
 import {
     dataSnapshotMaxSnapshotRateMutator,
+    proxyClientAuthMutator,
     proxyNumThreadsMutator,
     snapshotMigrationMaxConnectionsGatedMutator,
     snapshotMigrationMaxConnectionsMutator,
@@ -22,6 +23,7 @@ import {
 export function builtinMutators(): Mutator[] {
     return [
         proxyNumThreadsMutator(),
+        proxyClientAuthMutator(),
         dataSnapshotMaxSnapshotRateMutator(),
         snapshotMigrationMaxConnectionsGatedMutator(),
         snapshotMigrationMaxConnectionsMutator(),
@@ -34,6 +36,7 @@ export function builtinMutators(): Mutator[] {
  */
 export const BUILTIN_MUTATOR_NAMES: readonly string[] = [
     "proxy-numThreads",
+    "proxy-clientAuth",
     "dataSnapshot-maxSnapshotRate",
     "snapshotMigration-maxConnections-gated",
     "snapshotMigration-maxConnections",

--- a/orchestrationSpecs/packages/e2e-orchestration-tests/src/fixtures/mutators.ts
+++ b/orchestrationSpecs/packages/e2e-orchestration-tests/src/fixtures/mutators.ts
@@ -283,3 +283,62 @@ export function dataSnapshotMaxSnapshotRateMutator(): Mutator {
         },
     };
 }
+
+/**
+ * proxyClientAuthMutator — gated mutator for `captureproxy:capture-proxy`
+ * that exercises capture-proxy mutual-TLS (clientAuth).
+ *
+ * Sets `proxyConfig.tls.clientAuth` with an inline trusted client CA PEM
+ * (the form that regressed in #3069 / fixed in #3071). clientAuth lives in
+ * the gated `tls` subtree of USER_PROXY_OPTIONS, so changing it is a gated
+ * change: the workflow must surface the proxy retry/approval gate before
+ * proceeding. This case also guards the underlying apply path — before the
+ * fix, the resolved mTLS fields leaked into the CaptureProxy CR and the
+ * upsert step failed outright, which this spec would catch as a non-terminal
+ * failure rather than a gate.
+ *
+ * The mutation toggles `clientAuth.required` so a re-submission produces a
+ * detectable diff in the gated subtree.
+ */
+export function proxyClientAuthMutator(): Mutator {
+    const CLIENT_CA_PEM = [
+        "-----BEGIN CERTIFICATE-----",
+        "MIIBkTCB+wIJAJ2e2e2e2e2eMA0GCSqGSIb3DQEBCwUAMA0xCzAJBgNVBAYTAlVT",
+        "-----END CERTIFICATE-----",
+    ].join("\n");
+    return {
+        name: "proxy-clientAuth",
+        fieldChangeClass: "gated",
+        changeClass: "gated",
+        dependencyPattern: "subject-gated-change",
+        subject: "captureproxy:capture-proxy" as ComponentId,
+        expectedRerunComponents: ["captureproxy:capture-proxy" as ComponentId],
+        changedPaths: ["traffic.proxies.capture-proxy.proxyConfig.tls.clientAuth"],
+        approvalPattern: "captureproxy.capture-proxy",
+        apply(config: unknown): unknown {
+            const cloned = structuredClone(config);
+            const root = cloned as Record<string, unknown>;
+            const traffic = root["traffic"] as Record<string, unknown> | undefined;
+            if (!traffic) throw new Error("proxy-clientAuth mutator: missing 'traffic' key");
+            const proxies = traffic["proxies"] as Record<string, unknown> | undefined;
+            if (!proxies) throw new Error("proxy-clientAuth mutator: missing 'traffic.proxies' key");
+            const proxy = proxies["capture-proxy"] as Record<string, unknown> | undefined;
+            if (!proxy) throw new Error("proxy-clientAuth mutator: missing 'traffic.proxies.capture-proxy' key");
+            const proxyConfig = proxy["proxyConfig"] as Record<string, unknown> | undefined;
+            if (!proxyConfig) throw new Error("proxy-clientAuth mutator: missing 'traffic.proxies.capture-proxy.proxyConfig' key");
+            const existingTls = proxyConfig["tls"] as Record<string, unknown> | undefined;
+            const existingClientAuth = existingTls?.["clientAuth"] as Record<string, unknown> | undefined;
+            // Toggle `required` so a resubmission of an already-mTLS proxy is a real diff.
+            const required = existingClientAuth?.["required"] === true ? false : true;
+            proxyConfig["tls"] = {
+                mode: "existingSecret",
+                secretName: "proxy-tls",
+                clientAuth: {
+                    required,
+                    trustedClientCaPem: CLIENT_CA_PEM,
+                },
+            };
+            return cloned;
+        },
+    };
+}

--- a/orchestrationSpecs/packages/e2e-orchestration-tests/tests/builtinMutators.test.ts
+++ b/orchestrationSpecs/packages/e2e-orchestration-tests/tests/builtinMutators.test.ts
@@ -9,6 +9,7 @@ import { ScenarioSpec } from "../src/types";
 describe("builtinMutators", () => {
     it("exposes proxy-numThreads in BUILTIN_MUTATOR_NAMES", () => {
         expect(BUILTIN_MUTATOR_NAMES).toContain("proxy-numThreads");
+        expect(BUILTIN_MUTATOR_NAMES).toContain("proxy-clientAuth");
         expect(BUILTIN_MUTATOR_NAMES).toContain("dataSnapshot-maxSnapshotRate");
         expect(BUILTIN_MUTATOR_NAMES).toContain("snapshotMigration-maxConnections-gated");
         expect(BUILTIN_MUTATOR_NAMES).toContain("snapshotMigration-maxConnections");
@@ -50,6 +51,33 @@ describe("builtinMutators", () => {
         expect(cases[0].caseName).toBe(
             "captureproxy-capture-proxy-subject-change-proxy-numThreads",
         );
+    });
+
+    it("enables gated matrix expansion for capture-proxy clientAuth (mTLS)", () => {
+        const reg = new MutatorRegistry();
+        for (const m of builtinMutators()) reg.register(m);
+
+        const spec: ScenarioSpec = {
+            baseConfig: "./anything.yaml",
+            phaseCompletionTimeoutSeconds: 600,
+            matrix: {
+                subject: "captureproxy:capture-proxy",
+                select: [{
+                    changeClass: "gated",
+                    patterns: ["subject-gated-change"],
+                    response: "approve",
+                }],
+            },
+            lifecycle: { setup: [], teardown: [] },
+            approvalGates: [],
+            fixtures: {},
+        };
+        const cases = expandCases(spec, reg);
+        expect(cases).toHaveLength(1);
+        expect(cases[0].caseName).toBe(
+            "captureproxy-capture-proxy-subject-gated-change-proxy-clientAuth-approve",
+        );
+        expect(cases[0].response).toBe("approve");
     });
 
     it("enables matrix expansion for the basic snapshot-migration impossible spec", () => {

--- a/orchestrationSpecs/packages/e2e-orchestration-tests/tests/live-specs/fullMigrationProxyClientAuthGated.test.yaml
+++ b/orchestrationSpecs/packages/e2e-orchestration-tests/tests/live-specs/fullMigrationProxyClientAuthGated.test.yaml
@@ -1,0 +1,36 @@
+baseConfig: ../fixtures/fullMigrationWithTraffic.skipApprovals.wf.yaml
+phaseCompletionTimeoutSeconds: 600
+
+# Gated capture-proxy mTLS (clientAuth) change. clientAuth lives in the gated
+# `tls` subtree of the proxy config, so toggling it must surface the capture
+# proxy retry/approval gate before the workflow proceeds. This also guards the
+# regression in #3069 (fixed in #3071): before the fix the resolved mTLS fields
+# leaked into the CaptureProxy CR and the upsert step failed outright, which
+# would show up here as a non-terminal failure rather than a clean gate.
+#
+# Two responses are exercised:
+#   - leave-blocked: the gate appears and the workflow stays held.
+#   - approve:       approving the gate lets the change proceed and converge.
+matrix:
+  subject: captureproxy:capture-proxy
+  select:
+    - changeClass: gated
+      patterns: [subject-gated-change]
+      response: leave-blocked
+    - changeClass: gated
+      patterns: [subject-gated-change]
+      response: approve
+
+lifecycle:
+  setup: [create-basic-auth-secrets]
+  teardown: []
+
+fixtures:
+  basicAuthCredentials:
+    bySecretName:
+      source-creds:
+        usernameEnv: E2E_SOURCE_BASIC_AUTH_USERNAME
+        passwordEnv: E2E_SOURCE_BASIC_AUTH_PASSWORD
+      target-creds:
+        usernameEnv: E2E_TARGET_BASIC_AUTH_USERNAME
+        passwordEnv: E2E_TARGET_BASIC_AUTH_PASSWORD

--- a/orchestrationSpecs/packages/e2e-orchestration-tests/tests/mutators.test.ts
+++ b/orchestrationSpecs/packages/e2e-orchestration-tests/tests/mutators.test.ts
@@ -3,6 +3,7 @@ import {
     dataSnapshotMaxSnapshotRateMutator,
     Mutator,
     MutatorRegistry,
+    proxyClientAuthMutator,
     proxyNumThreadsMutator,
     snapshotMigrationMaxConnectionsGatedMutator,
     snapshotMigrationMaxConnectionsMutator,
@@ -281,5 +282,64 @@ describe("dataSnapshotMaxSnapshotRateMutator", () => {
             result.sourceClusters.source.snapshotInfo.snapshots.snap1.config
                 .createSnapshotConfig.maxSnapshotRateMbPerNode,
         ).toBe(1);
+    });
+});
+
+describe("proxyClientAuthMutator", () => {
+    const mutator = proxyClientAuthMutator();
+
+    it("has the expected gated metadata", () => {
+        expect(mutator.name).toBe("proxy-clientAuth");
+        expect(mutator.changeClass).toBe("gated");
+        expect(mutator.dependencyPattern).toBe("subject-gated-change");
+        expect(mutator.subject).toBe("captureproxy:capture-proxy");
+        expect(mutator.approvalPattern).toBe("captureproxy.capture-proxy");
+        expect(mutator.expectedRerunComponents).toEqual([
+            "captureproxy:capture-proxy",
+        ]);
+        expect(mutator.changedPaths).toEqual([
+            "traffic.proxies.capture-proxy.proxyConfig.tls.clientAuth",
+        ]);
+    });
+
+    it("apply() sets clientAuth without mutating the input", () => {
+        const input = {
+            traffic: {
+                proxies: {
+                    "capture-proxy": {
+                        proxyConfig: { listenPort: 9201 },
+                    },
+                },
+            },
+        };
+        const result = mutator.apply(input) as any;
+        // Input unchanged.
+        expect((input.traffic.proxies["capture-proxy"].proxyConfig as any).tls).toBeUndefined();
+        // Result has clientAuth in the gated tls subtree.
+        const tls = result.traffic.proxies["capture-proxy"].proxyConfig.tls;
+        expect(tls.clientAuth.required).toBe(true);
+        expect(typeof tls.clientAuth.trustedClientCaPem).toBe("string");
+        // Unrelated fields preserved.
+        expect(result.traffic.proxies["capture-proxy"].proxyConfig.listenPort).toBe(9201);
+    });
+
+    it("apply() toggles required when mTLS is already enabled", () => {
+        const input = {
+            traffic: {
+                proxies: {
+                    "capture-proxy": {
+                        proxyConfig: {
+                            tls: {
+                                mode: "existingSecret",
+                                secretName: "proxy-tls",
+                                clientAuth: { required: true, trustedClientCaPem: "x" },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const result = mutator.apply(input) as any;
+        expect(result.traffic.proxies["capture-proxy"].proxyConfig.tls.clientAuth.required).toBe(false);
     });
 });


### PR DESCRIPTION
### Description

Builds on the workflow-test framework in your #2690 branch (`WorkflowTest`) to add coverage for **capture-proxy mutual TLS (`clientAuth`)** — the path that regressed in opensearch-project#3069 and is fixed in **opensearch-project#3071**.

I'm targeting `WorkflowTest` directly so the framework and its first mTLS scenario land together; once #2690 merges this rides in with it. The product fix itself is the separate **opensearch-project#3071** (against `main`).

What this adds:
- **`proxyClientAuthMutator`** — a `gated` mutator on `captureproxy:capture-proxy` that sets `proxyConfig.tls.clientAuth` with an inline trusted client CA PEM and toggles `required` on resubmission. `clientAuth` lives in the `gated` `tls` subtree, so changing it must surface the capture-proxy approval gate before proceeding.
- Registration in `builtinMutators()` / `BUILTIN_MUTATOR_NAMES`.
- Unit tests: mutator metadata + `apply()` semantics, and gated matrix expansion resolving to `captureproxy-capture-proxy-subject-gated-change-proxy-clientAuth-*`.
- **`fullMigrationProxyClientAuthGated.test.yaml`** live-spec exercising both `leave-blocked` and `approve` responses.

Why it matters: before opensearch-project#3071 the resolved mTLS fields (`requireClientAuth`, `sslTrustCertPemEnvVar`, `sslTrustCertFile`) leaked into the `CaptureProxy` CR and the `upsertcaptureproxyresource` apply failed with a strict-decoding error. Against the unfixed product code this spec fails as a **non-terminal component failure** rather than a clean gate — i.e. it would have caught opensearch-project#3069. After #3071 it converges through the gate.

### Testing

- `npx jest --config packages/e2e-orchestration-tests/jest.config.js` — full unit suite green (245 tests, 18 suites), including the new mutator and matrix-expansion tests.
- The new live-spec runs under the framework's live-cluster path (`e2e-run`); it's not part of the cluster-free unit run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.